### PR TITLE
Reference JS & LRC file via CDN

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,7 +71,7 @@
       integrity="sha384-gtEjrD/SeCtmISkJkNUaaKMoLD0//ElJ19smozuHV6z3Iehds+3Ulb9Bn9Plx0x4"
       crossorigin="anonymous"
     ></script>
-    <script src="/js/lyricController.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/dark-knight404/bhaktamarstotra@main/js/lyricController.js"></script>
     <script>
       function ajax(url, returnType) {
         return new Promise(function (resolve, reject) {
@@ -114,7 +114,7 @@
         lyricsController.update(audio.currentTime);
       });
 
-      Promise.all([ajax("/assets/BhaktamarStotra.lrc.txt", "text")]).then(
+      Promise.all([ajax("https://cdn.jsdelivr.net/gh/dark-knight404/bhaktamarstotra@24c2b584653b20a7a7f039af379bf4ea176d7eb9/assets/BhaktamarStotra.lrc.txt", "text")]).then(
         function (res) {
           lyricsController.load(res[0]);
         }

--- a/js/lyricController.js
+++ b/js/lyricController.js
@@ -81,9 +81,9 @@
   }
 
   function textClicked(time) {
-    if ((isFirefox && time == "16.51") || time == "25.17") {
+    // Handle weird Firefox issue for the 2nd & 3rd lines
+    if (isFirefox && ((time == "16.51") || (time == "25.17"))) {
       time = time - 1.5;
-      console.log("Clicked:" + time + " CT:" + track.currentTime);
     }
     track.pause();
     track.currentTime = time;


### PR DESCRIPTION
- JS & LRC files were referenced statically, which didn't work with GH pages.
- Use JSDelivr URLs for these files.
- Fix a bug in textClicked() function.